### PR TITLE
Fix hardcoded bind all interfaces security issue

### DIFF
--- a/src/presentation/cli/commands/interactive_command.py
+++ b/src/presentation/cli/commands/interactive_command.py
@@ -939,7 +939,7 @@ class InteractiveMenu:
         self._display_header("Start Webhook Server")
 
         # Get webhook configuration
-        host = self._get_input("Enter host (default: 0.0.0.0): ", r"^[a-zA-Z0-9\.:]+$") or "0.0.0.0"
+        host = self._get_input("Enter host (default: 127.0.0.1): ", r"^[a-zA-Z0-9\.:]+$") or "127.0.0.1"
         port_str = self._get_input("Enter port (default: 5000): ", r"^\d*$") or "5000"
         port = int(port_str)
         path = self._get_input("Enter webhook path (default: /webhook): ", r"^/.*$") or "/webhook"
@@ -1037,7 +1037,7 @@ class InteractiveMenu:
 
         if hasattr(self, 'webhook_status') and self.webhook_status.get("running", False):
             # Server is running
-            host = self.webhook_status.get("host", "0.0.0.0")
+            host = self.webhook_status.get("host", "127.0.0.1")
             port = self.webhook_status.get("port", 5000)
             path = self.webhook_status.get("path", "/webhook")
             add_comments = self.webhook_status.get("add_comments", False)

--- a/src/presentation/cli/commands/webhook_command.py
+++ b/src/presentation/cli/commands/webhook_command.py
@@ -49,8 +49,8 @@ class WebhookCommand(Command):
         start_parser = subparsers.add_parser("start", help="Start the webhook server")
         start_parser.add_argument(
             "--host",
-            default="0.0.0.0",
-            help="Host to listen on (default: 0.0.0.0)"
+            default="127.0.0.1",
+            help="Host to listen on (default: 127.0.0.1)"
         )
 
         start_parser.add_argument(
@@ -143,7 +143,7 @@ class WebhookCommand(Command):
         Returns:
             Dictionary with execution results
         """
-        host = args.get("host", "0.0.0.0")
+        host = args.get("host", "127.0.0.1")
         port = args.get("port", 5000)
         path = args.get("path", "/webhook")
         add_comments = args.get("add_comments", False)


### PR DESCRIPTION
### **User description**
Changed default host binding from 0.0.0.0 to 127.0.0.1 to address Bandit security warning B104. This prevents accidentally exposing the webhook server to all network interfaces by default.

Users who need to bind to all interfaces can still explicitly specify 0.0.0.0 as the host.

Fixes:
- src/presentation/cli/commands/interactive_command.py:942
- src/presentation/cli/commands/interactive_command.py:1040
- src/presentation/cli/commands/webhook_command.py:52
- src/presentation/cli/commands/webhook_command.py:146

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Changed default host binding from 0.0.0.0 to 127.0.0.1

- Addresses Bandit security warning B104 for webhook server

- Prevents accidental exposure to all network interfaces

- Users can still explicitly specify 0.0.0.0 if needed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Default Host: 0.0.0.0"] -->|Security Risk| B["Bandit Warning B104"]
  C["Updated to 127.0.0.1"] -->|Localhost Only| D["Secure by Default"]
  E["User Override"] -->|Explicit 0.0.0.0| F["All Interfaces Available"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>interactive_command.py</strong><dd><code>Update interactive webhook default host binding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/presentation/cli/commands/interactive_command.py

<ul><li>Updated default host from 0.0.0.0 to 127.0.0.1 in webhook start prompt<br> <li> Changed fallback default in webhook status display<br> <li> Updated user-facing help text to reflect new default</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/zendesk-ai-integration/pull/9/files#diff-7c96c1fabd4468ea51fc0ff906fb0600ceebdcc4635d55fc06ac6ed86f60e770">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>webhook_command.py</strong><dd><code>Update webhook command default host binding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/presentation/cli/commands/webhook_command.py

<ul><li>Changed argument parser default from 0.0.0.0 to 127.0.0.1<br> <li> Updated help text for --host argument<br> <li> Modified fallback default in webhook start method</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/zendesk-ai-integration/pull/9/files#diff-0e320c9bffa9777fb83fb4f62ceedb445b19cbd9fa4dd16a65eff14b866d9512">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

