### PR TITLE
Fix test import errors after codebase refactoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ zenpy>=2.0.24
 # Database
 pymongo>=4.5.0
 
+# Caching
+cachetools>=5.3.0
+
 # AI Services
 openai>=1.0.0
 anthropic>=0.7.0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,9 +11,9 @@ import sys
 import os
 from datetime import datetime, timedelta
 
-# Import the cache manager
+# Import the cache manager from the new location
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from src.modules.cache_manager import ZendeskCache
+from src.infrastructure.cache.zendesk_cache_adapter import ZendeskCache
 
 @pytest.fixture(scope="session")
 def execution_id():
@@ -30,9 +30,9 @@ def isolated_cache_manager():
     Each test gets its own clean instance.
     """
     cache = ZendeskCache()
-    cache.clear_all()  # Start with a clean cache
+    cache.clear()  # Start with a clean cache
     yield cache
-    cache.clear_all()  # Clean up after test
+    cache.clear()  # Clean up after test
 
 @pytest.fixture
 def frozen_time():
@@ -96,8 +96,8 @@ def mock_claude_service():
     """
     Mock the Claude Service for testing.
     """
-    # Use patch to mock the call_claude_with_retries function
-    patcher = patch('src.claude_service.call_claude_with_retries')
+    # Use patch to mock the ClaudeService class
+    patcher = patch('src.infrastructure.external_services.claude_service.ClaudeService')
     mock = patcher.start()
     yield mock
     patcher.stop()
@@ -105,10 +105,10 @@ def mock_claude_service():
 @pytest.fixture
 def mock_enhanced_claude_service():
     """
-    Mock the Claude Enhanced Sentiment service for testing.
+    Mock the Enhanced Claude Service for testing.
     """
-    # Use patch to mock the call_claude_with_retries function
-    patcher = patch('src.claude_enhanced_sentiment.call_claude_with_retries')
+    # Use patch to mock the ClaudeService class (both use the same implementation now)
+    patcher = patch('src.infrastructure.external_services.claude_service.ClaudeService')
     mock = patcher.start()
     yield mock
     patcher.stop()
@@ -173,6 +173,6 @@ def mock_zendesk_client():
     mock_client.views.list.return_value = mock_views
     
     # The key part: mock both Zenpy import and instantiation
-    with patch('src.modules.zendesk_client.Zenpy', create=True) as mock_zenpy_class:
+    with patch('zenpy.Zenpy', create=True) as mock_zenpy_class:
         mock_zenpy_class.return_value = mock_client
         yield mock_client

--- a/tests/unit/test_cache_invalidation_fixed.py
+++ b/tests/unit/test_cache_invalidation_fixed.py
@@ -15,7 +15,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 # Import the cache manager
-from src.modules.cache_manager import ZendeskCache, TTLCacheWithInvalidation
+from src.infrastructure.cache.zendesk_cache_adapter import ZendeskCache, TTLCacheWithInvalidation
 
 class TestCacheInvalidationFixed:
     """Test suite for fixed cache invalidation functionality."""

--- a/tests/unit/test_cache_invalidation_improved.py
+++ b/tests/unit/test_cache_invalidation_improved.py
@@ -17,7 +17,7 @@ import random
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 # Import the cache manager
-from src.modules.cache_manager import ZendeskCache, TTLCacheWithInvalidation, CacheStatistics
+from src.infrastructure.cache.zendesk_cache_adapter import ZendeskCache, TTLCacheWithInvalidation, CacheStatistics
 
 class TestCacheInvalidationImproved:
     """Test suite for improved cache invalidation functionality."""

--- a/tests/unit/test_cache_manager.py
+++ b/tests/unit/test_cache_manager.py
@@ -15,7 +15,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 # Import module to test
-from src.modules.cache_manager import ZendeskCache
+from src.infrastructure.cache.zendesk_cache_adapter import ZendeskCache
 
 
 class TestZendeskCache:


### PR DESCRIPTION
### **User description**
This commit fixes import errors in unit tests that occurred after the codebase was refactored from a flat module structure (src.modules.*) to a clean architecture pattern with layers (domain, application, infrastructure, presentation).

Changes:
- Updated tests/unit/conftest.py to import from new module locations:
  * ZendeskCache: src.modules.cache_manager → src.infrastructure.cache.zendesk_cache_adapter
  * ClaudeService: src.claude_service → src.infrastructure.external_services.claude_service
  * Zenpy mock: src.modules.zendesk_client → zenpy.Zenpy

- Fixed ZendeskCache fixture to use clear() instead of clear_all() (ZendeskCache has clear(), ZendeskCacheManager has clear_all())

- Updated cache-related unit test imports:
  * test_cache_manager.py
  * test_cache_invalidation_fixed.py
  * test_cache_invalidation_improved.py

- Added missing cachetools dependency to requirements.txt (Required by ZendeskCache implementation)

This resolves the conftest.py import error that was blocking all unit tests: "ModuleNotFoundError: No module named 'src.modules'"

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Updated test imports to match clean architecture refactoring
  - ZendeskCache: `src.modules.cache_manager` → `src.infrastructure.cache.zendesk_cache_adapter`
  - ClaudeService: `src.claude_service` → `src.infrastructure.external_services.claude_service`
  - Zenpy mock: `src.modules.zendesk_client` → `zenpy.Zenpy`

- Fixed ZendeskCache fixture to use `clear()` instead of `clear_all()`

- Added missing `cachetools>=5.3.0` dependency to requirements.txt

- Updated cache-related test files with corrected import paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old flat structure<br/>src.modules.*"] -- "refactored to" --> B["Clean architecture<br/>domain/application/<br/>infrastructure/presentation"]
  B -- "requires" --> C["Updated test imports<br/>in conftest.py"]
  C -- "fixes" --> D["Unit tests<br/>now runnable"]
  E["Added cachetools<br/>dependency"] --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Updated fixture imports and cache method calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/conftest.py

<ul><li>Updated ZendeskCache import from <code>src.modules.cache_manager</code> to <br><code>src.infrastructure.cache.zendesk_cache_adapter</code><br> <li> Updated ClaudeService mock patch path to <br><code>src.infrastructure.external_services.claude_service.ClaudeService</code><br> <li> Updated Zenpy mock patch from <code>src.modules.zendesk_client.Zenpy</code> to <br><code>zenpy.Zenpy</code><br> <li> Changed cache fixture methods from <code>clear_all()</code> to <code>clear()</code> to match <br>ZendeskCache API<br> <li> Updated docstrings for clarity on mock targets</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/zendesk-ai-integration/pull/10/files#diff-0cae8a7ee2d37098b1ad84b543d17cfc1e8535eed5fd6abac88c668bfe354cbb">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_cache_invalidation_fixed.py</strong><dd><code>Updated cache import path for refactored structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_cache_invalidation_fixed.py

<ul><li>Updated import path for ZendeskCache and TTLCacheWithInvalidation from <br><code>src.modules.cache_manager</code> to <br><code>src.infrastructure.cache.zendesk_cache_adapter</code></ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/zendesk-ai-integration/pull/10/files#diff-75405b5c5110e8dbf6a852332316f8de19cb897b97150601ad8539a75c6d4667">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_cache_invalidation_improved.py</strong><dd><code>Updated cache import path for refactored structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_cache_invalidation_improved.py

<ul><li>Updated import path for ZendeskCache, TTLCacheWithInvalidation, and <br>CacheStatistics from <code>src.modules.cache_manager</code> to <br><code>src.infrastructure.cache.zendesk_cache_adapter</code></ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/zendesk-ai-integration/pull/10/files#diff-2ea52b7db6f1d4354310a7ef27d8e0d7dff3d0131b9f5d860679ce97d9c8e14c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_cache_manager.py</strong><dd><code>Updated cache import path for refactored structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_cache_manager.py

<ul><li>Updated import path for ZendeskCache from <code>src.modules.cache_manager</code> to <br><code>src.infrastructure.cache.zendesk_cache_adapter</code></ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/zendesk-ai-integration/pull/10/files#diff-311f94855f590461985c1aa244de8877a01f618bb4168a4b664f3bbdb2e22d2e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Added missing cachetools dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.txt

<ul><li>Added <code>cachetools>=5.3.0</code> dependency under new Caching section<br> <li> Required by ZendeskCache implementation in refactored infrastructure <br>layer</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/zendesk-ai-integration/pull/10/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

