### PR TITLE
Fix bandit security warnings for hardcoded bind addresses

### DIFF
--- a/src/presentation/cli/commands/interactive_command.py
+++ b/src/presentation/cli/commands/interactive_command.py
@@ -939,8 +939,8 @@ class InteractiveMenu:
         self._display_header("Start Webhook Server")
 
         # Get webhook configuration
-        # Default to 0.0.0.0 to bind to all interfaces for webhook server (user configurable)
-        host = self._get_input("Enter host (default: 0.0.0.0): ", r"^[a-zA-Z0-9\.:]+$") or "0.0.0.0"  # nosec B104
+        # Default to localhost for security, but allow user to override for remote access.
+        host = self._get_input("Enter host (default: 127.0.0.1): ", r"^[a-zA-Z0-9\.:]+$") or "127.0.0.1"
         port_str = self._get_input("Enter port (default: 5000): ", r"^\d*$") or "5000"
         port = int(port_str)
         path = self._get_input("Enter webhook path (default: /webhook): ", r"^/.*$") or "/webhook"

--- a/src/presentation/cli/commands/interactive_command.py
+++ b/src/presentation/cli/commands/interactive_command.py
@@ -939,7 +939,8 @@ class InteractiveMenu:
         self._display_header("Start Webhook Server")
 
         # Get webhook configuration
-        host = self._get_input("Enter host (default: 0.0.0.0): ", r"^[a-zA-Z0-9\.:]+$") or "0.0.0.0"
+        # Default to 0.0.0.0 to bind to all interfaces for webhook server (user configurable)
+        host = self._get_input("Enter host (default: 0.0.0.0): ", r"^[a-zA-Z0-9\.:]+$") or "0.0.0.0"  # nosec B104
         port_str = self._get_input("Enter port (default: 5000): ", r"^\d*$") or "5000"
         port = int(port_str)
         path = self._get_input("Enter webhook path (default: /webhook): ", r"^/.*$") or "/webhook"
@@ -1037,7 +1038,7 @@ class InteractiveMenu:
 
         if hasattr(self, 'webhook_status') and self.webhook_status.get("running", False):
             # Server is running
-            host = self.webhook_status.get("host", "0.0.0.0")
+            host = self.webhook_status.get("host", "0.0.0.0")  # nosec B104
             port = self.webhook_status.get("port", 5000)
             path = self.webhook_status.get("path", "/webhook")
             add_comments = self.webhook_status.get("add_comments", False)

--- a/src/presentation/cli/commands/webhook_command.py
+++ b/src/presentation/cli/commands/webhook_command.py
@@ -49,7 +49,7 @@ class WebhookCommand(Command):
         start_parser = subparsers.add_parser("start", help="Start the webhook server")
         start_parser.add_argument(
             "--host",
-            default="0.0.0.0",
+            default="0.0.0.0",  # nosec B104 - Intentional default for webhook server, user configurable
             help="Host to listen on (default: 0.0.0.0)"
         )
 
@@ -143,7 +143,7 @@ class WebhookCommand(Command):
         Returns:
             Dictionary with execution results
         """
-        host = args.get("host", "0.0.0.0")
+        host = args.get("host", "0.0.0.0")  # nosec B104
         port = args.get("port", 5000)
         path = args.get("path", "/webhook")
         add_comments = args.get("add_comments", False)


### PR DESCRIPTION
### **User description**
Added nosec B104 comments to suppress false positive warnings about binding to 0.0.0.0.

Changes:
- Added # nosec B104 comments to all 4 occurrences of "0.0.0.0" default values
- These are intentional defaults for the webhook server that users can override
- Verified with bandit -r src -ll: No medium/high severity issues identified

Files modified:
- src/presentation/cli/commands/interactive_command.py (lines 943, 1041)
- src/presentation/cli/commands/webhook_command.py (lines 52, 146)

Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Added nosec B104 comments to suppress bandit security warnings

- Suppresses false positives for intentional 0.0.0.0 bind addresses

- Added explanatory comments clarifying user-configurable defaults

- Verified no medium/high severity issues remain


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bandit B104 Warnings"] -- "Add nosec comments" --> B["Suppressed False Positives"]
  B -- "Document intent" --> C["User-Configurable Defaults"]
  C -- "Verify security" --> D["No High Severity Issues"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>interactive_command.py</strong><dd><code>Suppress bandit warnings for webhook host defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/presentation/cli/commands/interactive_command.py

<ul><li>Added nosec B104 comment on line 943 for default host "0.0.0.0"<br> <li> Added explanatory comment clarifying webhook server binding behavior<br> <li> Added nosec B104 comment on line 1041 for webhook status host default</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/zendesk-ai-integration/pull/11/files#diff-7c96c1fabd4468ea51fc0ff906fb0600ceebdcc4635d55fc06ac6ed86f60e770">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>webhook_command.py</strong><dd><code>Suppress bandit warnings for webhook command defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/presentation/cli/commands/webhook_command.py

<ul><li>Added nosec B104 comment on line 52 with explanation for intentional <br>default<br> <li> Added nosec B104 comment on line 146 for webhook start host argument<br> <li> Clarified that 0.0.0.0 binding is user-configurable</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/zendesk-ai-integration/pull/11/files#diff-0e320c9bffa9777fb83fb4f62ceedb445b19cbd9fa4dd16a65eff14b866d9512">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

