### PR TITLE
Fix secret scanning false positive in MongoDB documentation

### DIFF
--- a/docs/MONGODB_SETUP.md
+++ b/docs/MONGODB_SETUP.md
@@ -126,9 +126,11 @@ This script will:
 - Test connection string directly
 
 ### Connection String Format
-- Local without authentication: `mongodb://localhost:27017/database_name`
-- Local with authentication: `mongodb://username:password@localhost:27017/database_name?authSource=admin`
-- Atlas: `mongodb+srv://username:password@cluster.xxxxx.mongodb.net/database_name?retryWrites=true&w=majority`
+- Local without authentication: `mongodb://localhost:27017/<database_name>`
+- Local with authentication: `mongodb://<username>:<password>@localhost:27017/<database_name>?authSource=admin`
+- Atlas: `mongodb+srv://<username>:<password>@<cluster>.mongodb.net/<database_name>?retryWrites=true&w=majority`
+
+**Note:** Replace `<username>`, `<password>`, `<cluster>`, and `<database_name>` with your actual values.
 
 ## Advanced Configuration
 


### PR DESCRIPTION
### **User description**
Replace literal connection string examples with angle-bracket placeholders to prevent GitHub secret scanning from flagging documentation as leaked credentials.

Changes:
- Updated username:password to <username>:<password>
- Changed cluster.xxxxx to <cluster>
- Added clarifying note about replacing placeholders with actual values

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Replace literal credentials with angle-bracket placeholders in MongoDB connection string examples

- Prevent GitHub secret scanning from flagging documentation as leaked credentials

- Add clarifying note instructing users to replace placeholders with actual values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Literal credentials<br/>in examples"] -- "Replace with<br/>placeholders" --> B["Angle-bracket<br/>placeholders"]
  B -- "Add clarification<br/>note" --> C["User-friendly<br/>documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MONGODB_SETUP.md</strong><dd><code>Replace credentials with placeholders in connection examples</code></dd></summary>
<hr>

docs/MONGODB_SETUP.md

<ul><li>Replaced literal <code>username:password</code> with <code><username>:<password></code> in connection strings<br> <li> Changed <code>cluster.xxxxx</code> to <code><cluster></code> in Atlas connection string<br> <li> Updated <code>database_name</code> to <code><database_name></code> for consistency<br> <li> Added clarifying note explaining placeholder replacement requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/quanticsoul4772/zendesk-ai-integration/pull/15/files#diff-68bec83f4c1250d9ec1469f30af25e679a889f937bdc152b424ae863f0c4012f">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

